### PR TITLE
PAM-based and local-only PAM-less authentication

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -1,6 +1,7 @@
 image: alpine/edge
 packages:
   - go
+  - linux-pam-dev
 sources:
   - https://github.com/emersion/maddy
 tasks:

--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -244,3 +244,26 @@ No-op module. It doesn't need to be configured explicitly and can be referenced
 using `dummy` name. It can act as a filter, delivery target, and auth.
 provider.  In the latter case, it will accept any credentials, allowing any
 client to authenticate using any username and password (use with care!).
+
+### 'extauth' module
+
+Module for authentication using external helper binary.
+It looks for binary named maddy-auth-helper in $PATH and uses it for
+authentication.
+
+Protocol is very simple:
+Username and password are written to stdin, adding `\n` to the end. If binary
+exits with 0 status code - authentication is considered successful. If status
+code is 1 - authentication is failed. If status code is 2 - other unrelated
+error happened. Additional information should be written to stderr.
+
+```
+extauth default_auth
+```
+
+Valid configuration directives:
+* `helper`
+  Location of the helper binary.
+
+* `debug`
+  Verbose log only for this module.

--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -267,3 +267,10 @@ Valid configuration directives:
 
 * `debug`
   Verbose log only for this module.
+
+### 'pam' module
+
+Same as 'extauth' module but looks for [maddy-pam-helper] binary by default.
+
+[maddy-pam-helper][cmd/maddy-pam-helper]
+

--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -270,7 +270,15 @@ Valid configuration directives:
 
 ### 'pam' module
 
-Same as 'extauth' module but looks for [maddy-pam-helper] binary by default.
+Same as 'extauth' module but looks for [maddy-pam-helper] binary by default
+which implements authentication using PAM stack.
+
+### 'shadow' module
+
+Same as 'extauth' module but looks for [maddy-shadow-helper] binary by default
+which implements authenticaiton using local shadow database (/etc/shadow).
 
 [maddy-pam-helper][cmd/maddy-pam-helper]
+[maddy-shadow-helper][cmd/maddy-shadow-helper]
+
 

--- a/cmd/maddy-pam-helper/README.md
+++ b/cmd/maddy-pam-helper/README.md
@@ -1,0 +1,70 @@
+## maddy-pam-helper
+
+External setuid binary for interaction with shadow passwords database or other
+privileged objects necessary to run PAM authentication.
+
+### Building
+
+It is really easy to build it using any GCC:
+```
+gcc main.c -lpam -o maddy-pam-helper
+```
+
+Yes, it is not a Go binary.
+
+
+### Installation
+
+maddy-pam-helper is kinda dangerous binary and should not be allowed to be
+executed by everybody but maddy's user. At the same moment it needs to have
+access to read-protected files. For this reason installation should be done
+very carefully to make sure to not introduce any security "holes".
+
+#### First method
+
+```shell
+chown maddy: /usr/bin/maddy-pam-helper
+chmod u+x,g-x,o-x /usr/bin/maddy-pam-helper
+```
+
+Also maddy-pam-helper needs access to /etc/shadow, one of the ways to provide
+it is to set file capability CAP_DAC_READ_SEARCH:
+```
+setcap cap_dac_read_search+ep /usr/bin/maddy-pam-helper
+```
+
+#### Second method
+
+Another, less restrictive is to make it setuid-root (assuming you have both maddy user and group):
+```
+chown root:maddy /usr/bin/maddy-pam-helper
+chmod u+xs,g+x,o-x /usr/bin/maddy-pam-helper
+```
+
+#### Third method
+
+The best way actually is to create `shadow` group and grant access to
+/etc/shadow to it and then make maddy-pam-helper setgid-shadow:
+```
+groupadd shadow
+chown :shadow /etc/shadow
+chmod g+r /etc/shadow
+chown maddy:shadow /usr/bin/maddy-pam-helper
+chmod u+x,g+xs /usr/bin/maddy-pam-helper
+```
+
+Pick what works best for you.
+
+### PAM service
+
+maddy-pam-helper uses custom service instead of pretending to be su or sudo.
+Because of this you should configure PAM to accept it.
+
+Here is minimal example using local passwd/shadow database for authentication:
+```
+#%PAM-1.0
+auth		required	pam_unix.so
+account		required	pam_unix.so
+session		required	pam_unix.so
+```
+Put it into /etc/pam.d/maddy.

--- a/cmd/maddy-pam-helper/README.md
+++ b/cmd/maddy-pam-helper/README.md
@@ -60,10 +60,6 @@ Pick what works best for you.
 maddy-pam-helper uses custom service instead of pretending to be su or sudo.
 Because of this you should configure PAM to accept it.
 
-Here is minimal example using local passwd/shadow database for authentication:
-```
-#%PAM-1.0
-auth		required	pam_unix.so
-account		required	pam_unix.so
-```
-Put it into /etc/pam.d/maddy.
+Minimal example using local passwd/shadow database for authentication can be
+found in [maddy.conf][maddy.conf] file.
+It should be put into /etc/pam.d/maddy.

--- a/cmd/maddy-pam-helper/README.md
+++ b/cmd/maddy-pam-helper/README.md
@@ -65,6 +65,5 @@ Here is minimal example using local passwd/shadow database for authentication:
 #%PAM-1.0
 auth		required	pam_unix.so
 account		required	pam_unix.so
-session		required	pam_unix.so
 ```
 Put it into /etc/pam.d/maddy.

--- a/cmd/maddy-pam-helper/maddy.conf
+++ b/cmd/maddy-pam-helper/maddy.conf
@@ -1,0 +1,3 @@
+#%PAM-1.0
+auth	required	pam_unix.so
+account	required	pam_unix.so

--- a/cmd/maddy-pam-helper/main.c
+++ b/cmd/maddy-pam-helper/main.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <security/pam_appl.h>
+
+/*
+I really doublt it is a good idea to bring Go to the binary whose primary task
+is to call libpam using CGo anyway.
+*/
+
+struct pam_response *reply;
+
+int conv_func(int num_msg, const struct pam_message **msg, struct pam_response **resp, void *appdata_ptr) {
+    *resp = reply;
+    return PAM_SUCCESS;
+}
+
+int run() {
+    char *username = NULL, *password = NULL;
+    size_t username_buf_len = 0, password_buf_len = 0;
+
+    ssize_t username_len = getline(&username, &username_buf_len, stdin);
+    if (username_len < 0) {
+        perror("getline username");
+        return 2;
+    }
+
+    ssize_t password_len = getline(&password, &password_buf_len, stdin);
+    if (password_len < 0) {
+        perror("getline password");
+        return 2;
+    }
+
+    // Cut trailing \n.
+    username[username_len-1] = 0;
+    password[password_len-1] = 0;
+
+    const struct pam_conv local_conv = { conv_func, NULL };
+    pam_handle_t *local_auth = NULL;
+    int status = pam_start("maddy", username, &local_conv, &local_auth);
+    if (status != PAM_SUCCESS) {
+        fprintf(stderr, "pam_start: %s\n", pam_strerror(local_auth, status));
+        return 2;
+    }
+
+    reply = malloc(sizeof(struct pam_response));
+    reply->resp = password;
+    reply->resp_retcode = 0;
+    status = pam_authenticate(local_auth, PAM_SILENT|PAM_DISALLOW_NULL_AUTHTOK);
+    if (status != PAM_SUCCESS) {
+        if (status == PAM_AUTH_ERR || status == PAM_USER_UNKNOWN) {
+            return 1;
+        } else {
+            fprintf(stderr, "pam_authenticate: %s\n", pam_strerror(local_auth, status));
+            return 2;
+        }
+    }
+
+    status = pam_end(local_auth, status);
+    if (status != PAM_SUCCESS) {
+            fprintf(stderr, "pam_end: %s\n", pam_strerror(local_auth, status));
+            return 2;
+    }
+}
+
+#ifndef CGO
+int main() {
+    return run();
+}
+#endif

--- a/cmd/maddy-pam-helper/main.go
+++ b/cmd/maddy-pam-helper/main.go
@@ -1,0 +1,20 @@
+package main
+
+/*
+#cgo LDFLAGS: -lpam
+#cgo CFLAGS: -DCGO
+extern int run();
+*/
+import "C"
+import "os"
+
+/*
+Apparently, some people would not want to build it manually by calling GCC.
+Here we do it for them. Not going to tell them that resulting file is 800KiB
+bigger than one built using only C compiler.
+*/
+
+func main() {
+	i := int(C.run())
+	os.Exit(i)
+}

--- a/cmd/maddy-pam-helper/main.go
+++ b/cmd/maddy-pam-helper/main.go
@@ -2,7 +2,7 @@ package main
 
 /*
 #cgo LDFLAGS: -lpam
-#cgo CFLAGS: -DCGO
+#cgo CFLAGS: -DCGO -Wall -Wextra -Werror -Wno-unused-parameter -Wno-error=unused-parameter -Wpedantic -std=c99
 extern int run();
 */
 import "C"

--- a/cmd/maddy-shadow-helper/README.md
+++ b/cmd/maddy-shadow-helper/README.md
@@ -1,0 +1,47 @@
+## maddy-shadow-helper
+
+External setuid binary for interaction with shadow passwords database.
+Unlike maddy-shadow-helper it supports only local shadow database but it does
+not have any C dependencies.
+
+### Installation
+
+maddy-shadow-helper is kinda dangerous binary and should not be allowed to be
+executed by everybody but maddy's user. At the same moment it needs to have
+access to read-protected files. For this reason installation should be done
+very carefully to make sure to not introduce any security "holes".
+
+#### First method
+
+```shell
+chown maddy: /usr/bin/maddy-shadow-helper
+chmod u+x,g-x,o-x /usr/bin/maddy-shadow-helper
+```
+
+Also maddy-shadow-helper needs access to /etc/shadow, one of the ways to provide
+it is to set file capability CAP_DAC_READ_SEARCH:
+```
+setcap cap_dac_read_search+ep /usr/bin/maddy-shadow-helper
+```
+
+#### Second method
+
+Another, less restrictive is to make it setuid-root (assuming you have both maddy user and group):
+```
+chown root:maddy /usr/bin/maddy-shadow-helper
+chmod u+xs,g+x,o-x /usr/bin/maddy-shadow-helper
+```
+
+#### Third method
+
+The best way actually is to create `shadow` group and grant access to
+/etc/shadow to it and then make maddy-shadow-helper setgid-shadow:
+```
+groupadd shadow
+chown :shadow /etc/shadow
+chmod g+r /etc/shadow
+chown maddy:shadow /usr/bin/maddy-shadow-helper
+chmod u+x,g+xs /usr/bin/maddy-shadow-helper
+```
+
+Pick what works best for you.

--- a/cmd/maddy-shadow-helper/main.go
+++ b/cmd/maddy-shadow-helper/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/emersion/maddy/shadow"
+)
+
+func main() {
+	scnr := bufio.NewScanner(os.Stdin)
+
+	if !scnr.Scan() {
+		fmt.Fprintln(os.Stderr, scnr.Err())
+		os.Exit(2)
+	}
+	username := scnr.Text()
+
+	if !scnr.Scan() {
+		fmt.Fprintln(os.Stderr, scnr.Err())
+		os.Exit(2)
+	}
+	password := scnr.Text()
+
+	ent, err := shadow.Lookup(username)
+	if err != nil {
+		if err == shadow.ErrNoSuchUser {
+			os.Exit(1)
+		}
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+
+	if !ent.IsAccountValid() {
+		fmt.Fprintln(os.Stderr, "account is expired")
+		os.Exit(1)
+	}
+
+	if !ent.IsPasswordValid() {
+		fmt.Fprintln(os.Stderr, "password is expired")
+		os.Exit(1)
+	}
+
+	if err := ent.VerifyPassword(password); err != nil {
+		if err == shadow.ErrWrongPassword {
+			os.Exit(1)
+		}
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/externalauth.go
+++ b/externalauth.go
@@ -1,0 +1,111 @@
+package maddy
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/emersion/maddy/config"
+	"github.com/emersion/maddy/log"
+	"github.com/emersion/maddy/module"
+)
+
+type ExternalAuth struct {
+	modName    string
+	instName   string
+	helperPath string
+
+	Log log.Logger
+}
+
+func NewExternalAuth(modName, instName string) (module.Module, error) {
+	ea := &ExternalAuth{
+		modName:  modName,
+		instName: instName,
+		Log:      log.Logger{Out: log.StderrLog, Name: modName},
+	}
+
+	return ea, nil
+}
+
+func (ea *ExternalAuth) Name() string {
+	return ea.modName
+}
+
+func (ea *ExternalAuth) InstanceName() string {
+	return ea.instName
+}
+
+func (ea *ExternalAuth) Init(globalCfg map[string]config.Node, rawCfg config.Node) error {
+	cfg := config.Map{}
+	cfg.Bool("debug", true, &ea.Log.Debug)
+	cfg.String("helper", false, false, "", &ea.helperPath)
+	if _, err := cfg.Process(globalCfg, &rawCfg); err != nil {
+		return err
+	}
+
+	if ea.helperPath != "" {
+		ea.Log.Debugln("using helper:", ea.helperPath)
+		return nil
+	}
+
+	helperName := "maddy-auth-helper"
+	switch ea.modName {
+	// TODO: PAM
+	// TODO: Local
+	}
+
+	var err error
+	ea.helperPath, err = exec.LookPath(helperName)
+	if err != nil {
+		return fmt.Errorf("no %s authentication support, %s is not found in $PATH and no custom path is set", ea.modName, helperName)
+	}
+
+	ea.Log.Debugln("using helper:", ea.helperPath)
+
+	return nil
+}
+
+func (ea *ExternalAuth) CheckPlain(username, password string) bool {
+	cmd := exec.Command(ea.helperPath)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		ea.Log.Println("failed to obtain stdin pipe for helper process:", err)
+		return false
+	}
+
+	if err := cmd.Start(); err != nil {
+		ea.Log.Println("failed to start helper process:", err)
+		return false
+	}
+
+	if _, err := io.WriteString(stdin, username+"\n"); err != nil {
+		ea.Log.Println("failed to write stdin of helper process:", err)
+		return false
+	}
+	if _, err := io.WriteString(stdin, password+"\n"); err != nil {
+		ea.Log.Println("failed to write stdin of helper process:", err)
+		return false
+	}
+
+	if err := cmd.Wait(); err != nil {
+		ea.Log.Debugln(err)
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			// Exit code 1 is for authentication failure.
+			// Exit code 2 is for other errors.
+			if exitErr.ExitCode() == 2 {
+				ea.Log.Println(strings.TrimSpace(string(exitErr.Stderr)))
+			}
+		} else {
+			ea.Log.Println("failed to wait for helper process:", err)
+		}
+		return false
+	}
+
+	return true
+}
+
+func init() {
+	module.Register("extauth", NewExternalAuth)
+}

--- a/externalauth.go
+++ b/externalauth.go
@@ -54,7 +54,8 @@ func (ea *ExternalAuth) Init(globalCfg map[string]config.Node, rawCfg config.Nod
 	switch ea.modName {
 	case "pam":
 		helperName = "maddy-pam-helper"
-		// TODO: Local
+	case "shadow":
+		helperName = "maddy-shadow-helper"
 	}
 
 	var err error
@@ -110,4 +111,5 @@ func (ea *ExternalAuth) CheckPlain(username, password string) bool {
 func init() {
 	module.Register("extauth", NewExternalAuth)
 	module.Register("pam", NewExternalAuth)
+	module.Register("shadow", NewExternalAuth)
 }

--- a/externalauth.go
+++ b/externalauth.go
@@ -52,8 +52,9 @@ func (ea *ExternalAuth) Init(globalCfg map[string]config.Node, rawCfg config.Nod
 
 	helperName := "maddy-auth-helper"
 	switch ea.modName {
-	// TODO: PAM
-	// TODO: Local
+	case "pam":
+		helperName = "maddy-pam-helper"
+		// TODO: Local
 	}
 
 	var err error
@@ -108,4 +109,5 @@ func (ea *ExternalAuth) CheckPlain(username, password string) bool {
 
 func init() {
 	module.Register("extauth", NewExternalAuth)
+	module.Register("pam", NewExternalAuth)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/emersion/maddy
 
 require (
+	github.com/GehirnInc/crypt v0.0.0-20190301055215-6c0105aabd46
 	github.com/emersion/go-dkim v0.0.0-20181215182626-18000c30d4b8
 	github.com/emersion/go-imap v1.0.0-beta.2
 	github.com/emersion/go-imap-appendlimit v0.0.0-20190308131241-25671c986a6a

--- a/shadow/read_shadow.go
+++ b/shadow/read_shadow.go
@@ -1,0 +1,80 @@
+package shadow
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+var ErrNoSuchUser = errors.New("shadow: user entry is not present in database")
+var ErrWrongPassword = errors.New("shadow: wrong password")
+
+// Read reads system shadow passwords database and returns all entires in it.
+func Read() ([]Entry, error) {
+	f, err := os.Open("/etc/shadow")
+	if err != nil {
+		return nil, err
+	}
+	scnr := bufio.NewScanner(f)
+
+	var res []Entry
+	for scnr.Scan() {
+		ent, err := parseEntry(scnr.Text())
+		if err != nil {
+			return res, err
+		}
+
+		res = append(res, *ent)
+	}
+	if err := scnr.Err(); err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+func parseEntry(line string) (*Entry, error) {
+	parts := strings.Split(line, ":")
+	if len(parts) != 9 {
+		return nil, errors.New("read: malformed entry")
+	}
+
+	res := &Entry{
+		Name: parts[0],
+		Pass: parts[1],
+	}
+	var err error
+
+	for i, value := range [...]*int{
+		&res.LastChange, &res.MinPassAge, &res.MaxPassAge,
+		&res.WarnPeriod, &res.InactivityPeriod, &res.AcctExpiry, &res.Flags,
+	} {
+		if parts[2+i] == "" {
+			*value = -1
+		} else {
+			*value, err = strconv.Atoi(parts[2+i])
+			if err != nil {
+				return nil, fmt.Errorf("read: invalid value for field %d", 2+i)
+			}
+		}
+	}
+
+	return res, nil
+}
+
+func Lookup(name string) (*Entry, error) {
+	entries, err := Read()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if entry.Name == name {
+			return &entry, nil
+		}
+	}
+
+	return nil, ErrNoSuchUser
+}

--- a/shadow/read_shadow.go
+++ b/shadow/read_shadow.go
@@ -45,7 +45,6 @@ func parseEntry(line string) (*Entry, error) {
 		Name: parts[0],
 		Pass: parts[1],
 	}
-	var err error
 
 	for i, value := range [...]*int{
 		&res.LastChange, &res.MinPassAge, &res.MaxPassAge,
@@ -54,6 +53,7 @@ func parseEntry(line string) (*Entry, error) {
 		if parts[2+i] == "" {
 			*value = -1
 		} else {
+			var err error
 			*value, err = strconv.Atoi(parts[2+i])
 			if err != nil {
 				return nil, fmt.Errorf("read: invalid value for field %d", 2+i)

--- a/shadow/shadow.go
+++ b/shadow/shadow.go
@@ -1,0 +1,46 @@
+// shadow package implements utilities for parsing and using shadow password
+// database on Unix systems.
+package shadow
+
+type Entry struct {
+	// User login name.
+	Name string
+
+	// Hashed user password.
+	Pass string
+
+	// Days since Jan 1, 1970 password was last changed.
+	LastChange int
+
+	// The number of days the user will have to wait before she will be allowed to
+	// change her password again.
+	//
+	// -1 if password aging is disabled.
+	MinPassAge int
+
+	// The number of days after which the user will have to change her password.
+	//
+	// -1 is password aging is disabled.
+	MaxPassAge int
+
+	// The number of days before a password is going to expire (see the maximum
+	// password age above) during which the user should be warned.
+	//
+	// -1 is password aging is disabled.
+	WarnPeriod int
+
+	// The number of days after a password has expired (see the maximum
+	// password age above) during which the password should still be accepted.
+	//
+	// -1 is password aging is disabled.
+	InactivityPeriod int
+
+	// The date of expiration of the account, expressed as the number of days
+	// since Jan 1, 1970.
+	//
+	// -1 is account never expires.
+	AcctExpiry int
+
+	// Unused now.
+	Flags int
+}

--- a/shadow/verify_shadow.go
+++ b/shadow/verify_shadow.go
@@ -1,0 +1,58 @@
+package shadow
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/GehirnInc/crypt"
+	_ "github.com/GehirnInc/crypt/apr1_crypt"
+	_ "github.com/GehirnInc/crypt/md5_crypt"
+	_ "github.com/GehirnInc/crypt/sha256_crypt"
+	_ "github.com/GehirnInc/crypt/sha512_crypt"
+)
+
+const SecsInDay = 86400
+
+func (e *Entry) IsAccountValid() bool {
+	if e.AcctExpiry == -1 {
+		return true
+	}
+
+	nowDays := int(time.Now().Unix() / SecsInDay)
+	return nowDays < e.AcctExpiry
+}
+
+func (e *Entry) IsPasswordValid() bool {
+	if e.LastChange == -1 || e.MaxPassAge == -1 || e.InactivityPeriod == -1 {
+		return true
+	}
+
+	nowDays := int(time.Now().Unix() / SecsInDay)
+	return nowDays < e.LastChange+e.MaxPassAge+e.InactivityPeriod
+}
+
+func (e *Entry) VerifyPassword(pass string) (err error) {
+	// Do not permit null and locked passwords.
+	if e.Pass == "" {
+		return errors.New("verify: null password")
+	}
+	if e.Pass[0] == '!' {
+		return errors.New("verify: locked password")
+	}
+
+	// crypt.NewFromHash may panic on unknown hash function.
+	defer func() {
+		if rcvr := recover(); rcvr != nil {
+			err = fmt.Errorf("%v", rcvr)
+		}
+	}()
+
+	if err := crypt.NewFromHash(e.Pass).Verify(e.Pass, []byte(pass)); err != nil {
+		if err == crypt.ErrKeyMismatch {
+			return ErrWrongPassword
+		}
+		return err
+	}
+	return nil
+}

--- a/shadow/verify_shadow.go
+++ b/shadow/verify_shadow.go
@@ -12,14 +12,14 @@ import (
 	_ "github.com/GehirnInc/crypt/sha512_crypt"
 )
 
-const SecsInDay = 86400
+const secsInDay = 86400
 
 func (e *Entry) IsAccountValid() bool {
 	if e.AcctExpiry == -1 {
 		return true
 	}
 
-	nowDays := int(time.Now().Unix() / SecsInDay)
+	nowDays := int(time.Now().Unix() / secsInDay)
 	return nowDays < e.AcctExpiry
 }
 
@@ -28,7 +28,7 @@ func (e *Entry) IsPasswordValid() bool {
 		return true
 	}
 
-	nowDays := int(time.Now().Unix() / SecsInDay)
+	nowDays := int(time.Now().Unix() / secsInDay)
 	return nowDays < e.LastChange+e.MaxPassAge+e.InactivityPeriod
 }
 


### PR DESCRIPTION
Implemented as an external binary helper to isolate privileged code. This PR also adds a generic extauth module to allow easy extension using 3rd-party authentication helpers.

The current recommended approach for installation is to grant helper binary additional permissions (setgid shadow, setuid root or CAP_DAC_READ_SEARCH) and restrict it to be runnable only by maddy user.

I decided to write a PAM helper in C because 100% of its code should call C library anyway. The code in Go would be much messier because of callbacks.

Closes #21.
Closes #20.