### PR TITLE
Support more logging targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ These can be specified only outside of any configuration block.
   * `syslog`
     Send logs to the local syslog daemon.
   * `off`
-    Do nothing. Useful to disable logging fully: `log off`
+    Do nothing. Used to disable logging fully: `log off`
+    Can't be combined with other targets.
   * file path
     Write (append) logs to file..
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ These can be specified only outside of any configuration block.
   Target can be one of the following:
   * `stderr`
     Write logs to stderr, this is the default.
+  * `syslog`
+    Send logs to the local syslog daemon.
   * `off`
     Do nothing. Useful to disable logging fully: `log off`
   * file path

--- a/README.md
+++ b/README.md
@@ -70,6 +70,30 @@ are options that can be used like that:
   Default TLS certificate to use. See
   [CONFIG_REFERENCE.md](CONFIG_REFERENCE.md) for details.
 
+* `debug`
+  Write verbose logs describing what exactly is happening and how its going.
+  Default mode is relatively quiet and still produces useful logs so
+  you need that only for debugging purposes.
+
+#### Options usable only at global level
+
+These can be specified only outside of any configuration block.
+
+* `log <targets...>`
+  Write log to one of more "targets".
+  Target can be one of the following:
+  * `stderr`
+    Write logs to stderr, this is the default.
+  * `off`
+    Do nothing. Useful to disable logging fully: `log off`
+  * file path
+    Write (append) logs to file..
+
+  For example:
+  ```
+  log off /log
+  ```
+
 ### Defaults
 
 Maddy provides reasonable defaults so you can start using it without spending

--- a/config.go
+++ b/config.go
@@ -142,7 +142,10 @@ func logOutput(m *config.Map, node *config.Node) (interface{}, error) {
 			}
 			outs = append(outs, syslogOut)
 		case "off":
-			outs = append(outs, nil)
+			if len(node.Args) != 1 {
+				return nil, errors.New("'off' can't be combined with other log targets")
+			}
+			return nil, nil
 		default:
 			w, err := os.OpenFile(arg, os.O_RDWR, os.ModePerm)
 			if err != nil {

--- a/config.go
+++ b/config.go
@@ -135,6 +135,12 @@ func logOutput(m *config.Map, node *config.Node) (interface{}, error) {
 		switch arg {
 		case "stderr":
 			outs = append(outs, log.StderrLog())
+		case "syslog":
+			syslogOut, err := log.Syslog()
+			if err != nil {
+				return nil, fmt.Errorf("failed to connect to syslog daemon: %v", err)
+			}
+			outs = append(outs, syslogOut)
 		case "off":
 			outs = append(outs, nil)
 		default:

--- a/externalauth.go
+++ b/externalauth.go
@@ -23,7 +23,7 @@ func NewExternalAuth(modName, instName string) (module.Module, error) {
 	ea := &ExternalAuth{
 		modName:  modName,
 		instName: instName,
-		Log:      log.Logger{Out: log.StderrLog, Name: modName},
+		Log:      log.Logger{Name: modName},
 	}
 
 	return ea, nil

--- a/imap.go
+++ b/imap.go
@@ -40,7 +40,7 @@ type IMAPEndpoint struct {
 func NewIMAPEndpoint(_, instName string) (module.Module, error) {
 	endp := &IMAPEndpoint{
 		name: instName,
-		Log:  log.Logger{Out: log.StderrLog, Name: "imap"},
+		Log:  log.Logger{Name: "imap"},
 	}
 	endp.name = instName
 

--- a/log/log.go
+++ b/log/log.go
@@ -105,7 +105,7 @@ func Syslog() (FuncLog, error) {
 		}
 
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "!!! Failed to send message to syslog daemon: %v", err)
+			fmt.Fprintf(os.Stderr, "!!! Failed to send message to syslog daemon: %v\n", err)
 		}
 	}, nil
 }

--- a/log/log.go
+++ b/log/log.go
@@ -55,6 +55,10 @@ func (l *Logger) log(debug bool, s string) {
 	if l.Name != "" {
 		s = l.Name + ": " + s
 	}
+
+	if l.Out == nil {
+		DefaultLogger.Out(time.Now(), debug, s)
+	}
 	l.Out(time.Now(), debug, s)
 }
 

--- a/maddy.go
+++ b/maddy.go
@@ -22,6 +22,7 @@ func Start(cfg []config.Node) error {
 	globals := config.NewMap(nil, &config.Node{Children: cfg})
 	globals.String("hostname", false, false, "", nil)
 	globals.Custom("tls", false, true, nil, tlsDirective, nil)
+	globals.Custom("log", false, false, defaultLogOutput, logOutput, &log.DefaultLogger.Out)
 	globals.Bool("debug", false, &log.DefaultLogger.Debug)
 	globals.AllowUnknown()
 	unmatched, err := globals.Process()

--- a/smtp.go
+++ b/smtp.go
@@ -109,7 +109,7 @@ func NewSMTPEndpoint(modName, instName string) (module.Module, error) {
 	endp := &SMTPEndpoint{
 		name:       instName,
 		submission: modName == "submission",
-		Log:        log.Logger{Out: log.StderrLog, Name: "smtp"},
+		Log:        log.Logger{Name: "smtp"},
 	}
 	return endp, nil
 }

--- a/sql.go
+++ b/sql.go
@@ -42,7 +42,7 @@ func (sqlm *SQLStorage) InstanceName() string {
 func NewSQLStorage(_, instName string) (module.Module, error) {
 	return &SQLStorage{
 		instName: instName,
-		Log:      log.Logger{Out: log.StderrLog, Name: "sql"},
+		Log:      log.Logger{Name: "sql"},
 	}, nil
 }
 


### PR DESCRIPTION
Includes support for logging to file and to the local syslog daemon. No support for log reopen on signal though. Depends on #31.

Closes #26.