### PR TITLE
Lazy modules initialization

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,9 +13,9 @@ Config matchers for module interfaces.
 */
 
 func authProvider(modName string) (module.AuthProvider, error) {
-	modObj := module.GetInstance(modName)
-	if modObj == nil {
-		return nil, fmt.Errorf("unknown auth. provider instance: %s", modName)
+	modObj, err := module.GetInstance(modName)
+	if err != nil {
+		return nil, err
 	}
 
 	provider, ok := modObj.(module.AuthProvider)
@@ -42,9 +42,9 @@ func authDirective(m *config.Map, node *config.Node) (interface{}, error) {
 }
 
 func storageBackend(modName string) (module.Storage, error) {
-	modObj := module.GetInstance(modName)
-	if modObj == nil {
-		return nil, fmt.Errorf("unknown storage backend instance: %s", modName)
+	modObj, err := module.GetInstance(modName)
+	if err != nil {
+		return nil, err
 	}
 
 	backend, ok := modObj.(module.Storage)
@@ -71,9 +71,9 @@ func storageDirective(m *config.Map, node *config.Node) (interface{}, error) {
 }
 
 func deliveryTarget(modName string) (module.DeliveryTarget, error) {
-	mod := module.GetInstance(modName)
+	mod, err := module.GetInstance(modName)
 	if mod == nil {
-		return nil, fmt.Errorf("unknown delivery target instance: %s", modName)
+		return nil, err
 	}
 
 	target, ok := mod.(module.DeliveryTarget)

--- a/dummy.go
+++ b/dummy.go
@@ -37,5 +37,5 @@ func (d Dummy) Init(_ *config.Map) error {
 
 func init() {
 	module.Register("dummy", nil)
-	module.RegisterInstance(&Dummy{instName: "dummy"})
+	module.RegisterInstance(&Dummy{instName: "dummy"}, nil)
 }

--- a/maddy.go
+++ b/maddy.go
@@ -44,7 +44,7 @@ func Start(cfg []config.Node) error {
 			return fmt.Errorf("%s:%d: unknown module: %s", block.File, block.Line, modName)
 		}
 
-		if mod := module.GetUninitedInstance(instName); mod != nil {
+		if module.HasInstance(instName) {
 			return fmt.Errorf("%s:%d: module instance named %s already exists", block.File, block.Line, instName)
 		}
 

--- a/module/instances.go
+++ b/module/instances.go
@@ -1,0 +1,69 @@
+package module
+
+import (
+	"fmt"
+
+	"github.com/emersion/maddy/config"
+	"github.com/emersion/maddy/log"
+)
+
+var (
+	Instances = make(map[string]struct {
+		mod Module
+		cfg *config.Map
+	})
+
+	Initialized = make(map[string]bool)
+)
+
+// Register adds module instance to the global registry.
+//
+// Instnace name must be unique. Second RegisterInstance with same instance
+// name will replace previous.
+func RegisterInstance(inst Module, cfg *config.Map) {
+	Instances[inst.InstanceName()] = struct {
+		mod Module
+		cfg *config.Map
+	}{inst, cfg}
+}
+
+// GetUninitedInstance returns module instance from global registry.
+//
+// Nil is returned if no module instance with specified name is Instances.
+//
+// Note that this function may return uninitialized module. If you need to ensure
+// that it is safe to interact with module instance - use GetInstance instead.
+func GetUninitedInstance(name string) Module {
+	mod, ok := Instances[name]
+	if !ok {
+		return nil
+	}
+
+	return mod.mod
+}
+
+// GetInstance returns module instance from global registry, initializing it if
+// necessary.
+//
+// Error is returned if module initialization fails or module instance does not
+// exists.
+func GetInstance(name string) (Module, error) {
+	mod, ok := Instances[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown module instance: %s", name)
+	}
+
+	// Break circular dependencies.
+	if Initialized[name] {
+		log.Debugln("module init", mod.mod.Name(), name, "(lazy init skipped)")
+		return mod.mod, nil
+	}
+
+	log.Debugln("module init", mod.mod.Name(), name, "(lazy)")
+	Initialized[name] = true
+	if err := mod.mod.Init(mod.cfg); err != nil {
+		return mod.mod, err
+	}
+
+	return mod.mod, nil
+}

--- a/module/instances.go
+++ b/module/instances.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	Instances = make(map[string]struct {
+	instances = make(map[string]struct {
 		mod Module
 		cfg *config.Map
 	})
@@ -21,25 +21,15 @@ var (
 // Instnace name must be unique. Second RegisterInstance with same instance
 // name will replace previous.
 func RegisterInstance(inst Module, cfg *config.Map) {
-	Instances[inst.InstanceName()] = struct {
+	instances[inst.InstanceName()] = struct {
 		mod Module
 		cfg *config.Map
 	}{inst, cfg}
 }
 
-// GetUninitedInstance returns module instance from global registry.
-//
-// Nil is returned if no module instance with specified name is Instances.
-//
-// Note that this function may return uninitialized module. If you need to ensure
-// that it is safe to interact with module instance - use GetInstance instead.
-func GetUninitedInstance(name string) Module {
-	mod, ok := Instances[name]
-	if !ok {
-		return nil
-	}
-
-	return mod.mod
+func HasInstance(name string) bool {
+	_, ok := instances[name]
+	return ok
 }
 
 // GetInstance returns module instance from global registry, initializing it if
@@ -48,7 +38,7 @@ func GetUninitedInstance(name string) Module {
 // Error is returned if module initialization fails or module instance does not
 // exists.
 func GetInstance(name string) (Module, error) {
-	mod, ok := Instances[name]
+	mod, ok := instances[name]
 	if !ok {
 		return nil, fmt.Errorf("unknown module instance: %s", name)
 	}

--- a/module/registry.go
+++ b/module/registry.go
@@ -33,36 +33,3 @@ func Get(name string) FuncNewModule {
 
 	return modules[name]
 }
-
-var instances = make(map[string]Module)
-var instancesLck sync.RWMutex
-
-// Register adds module instance to global registry.
-//
-// Instnace name must be unique. Second RegisterInstance with same instance
-// name will replace previous.
-func RegisterInstance(inst Module) {
-	instancesLck.Lock()
-	defer instancesLck.Unlock()
-
-	instances[inst.InstanceName()] = inst
-}
-
-// GetInstance returns module instance from global registry.
-//
-// Nil is returned if no module instance with specified name is registered.
-func GetInstance(name string) Module {
-	instancesLck.RLock()
-	defer instancesLck.RUnlock()
-
-	return instances[name]
-}
-
-// UnregisterInstance undoes effect of RegisterInstance, removing instance from
-// global registry.
-func UnregisterInstance(name string) {
-	instancesLck.Lock()
-	defer instancesLck.Unlock()
-
-	delete(instances, name)
-}

--- a/smtppipeline.go
+++ b/smtppipeline.go
@@ -180,8 +180,8 @@ func filterStepFromCfg(node config.Node) (SMTPPipelineStep, error) {
 		return nil, errors.New("filter: expected at least one argument")
 	}
 
-	modInst := module.GetInstance(node.Args[0])
-	if modInst == nil {
+	modInst, err := module.GetInstance(node.Args[0])
+	if err != nil {
 		return nil, fmt.Errorf("filter: unknown module instance: %s", node.Args[0])
 	}
 
@@ -201,8 +201,8 @@ func deliveryStepFromCfg(node config.Node) (SMTPPipelineStep, error) {
 		return nil, errors.New("delivery: expected at least one argument")
 	}
 
-	modInst := module.GetInstance(node.Args[0])
-	if modInst == nil {
+	modInst, err := module.GetInstance(node.Args[0])
+	if err != nil {
 		return nil, fmt.Errorf("delivery: unknown module instance: %s", node.Args[0])
 	}
 


### PR DESCRIPTION
Lazily initialize modules as they are requested. This fixes the initialization ordering issue introduced in fd14e52e459c31bda8974ec498bac77de283725a. Depends on #31.