### PR TITLE
Implement destination pipeline step

### DIFF
--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -153,6 +153,9 @@ You can add any number of steps you want using following directives:
   Executes all nested steps if the condition specified in the directive is true
   (field contains the specified substring).
 
+  **Note:** `match` is a low-level dispatching primitive, in most cases you should
+  use `destination` instead.
+
   If the substring is wrapped in forward slashes - it will be interpreted as a
   Perl-compatible regular expression that should match field contents.
 
@@ -174,29 +177,35 @@ You can add any number of steps you want using following directives:
 
     Example:
     ```
-    match rcpt "/@emersion.fr$/" {
+    match rcpt_domain emersion.fr {
         filter dkim verify
         deliver local
     }
     ```
-
 
 * `destination <recipient...> { ... }`
 
   Execute subblock only if message does have at least one recipient matching
   any of the specified rules.
 
-  "Rule" can be either domain name, full address or regular expression.
+  "Rule" can be either domain name, full address (should include `@`) or regular expression.
 
   **Note:** If rule matches recipient - it will be removed from delivery context,
-    thus no steps after this destination block will see this recipient.
-
+  thus no steps after this destination block will see this recipient.
   This ensures that the following example will not deliver message to both 
+
+  **Note 2:** Don't forget that order of pipeline steps matters.
+  ```
+  deliver sql
+  destination postmaster@example.org { deliver local }
+  ```
+  In this case messages for postmaster@example.org will be delivered to
+  **both** 'sql' and 'local' storage.
 
   Example: Deliver to "local" all messages for mailboxes on example.org and all other - to "dummy".
   ```
-  destination example.org { delivery local }
-  delivery dummy
+  destination example.org { deliver local }
+  deliver dummy
   ```
 
 

--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -175,38 +175,27 @@ You can add any number of steps you want using following directives:
   - `src_hostname`
     Hostname reported by the client in the EHLO/HELO command.
 
-    Example:
-    ```
-    match rcpt_domain emersion.fr {
-        filter dkim verify
-        deliver local
-    }
-    ```
-
 * `destination <recipient...> { ... }`
 
-  Execute subblock only if message does have at least one recipient matching
-  any of the specified rules.
+  For all recipients that match at least one rule - execute subblock and stop
+  processing, for all others - skip block and continue.
 
-  "Rule" can be either domain name, full address (should include `@`) or regular expression.
-
-  **Note:** If rule matches recipient - it will be removed from delivery context,
-  thus no steps after this destination block will see this recipient.
-  This ensures that the following example will not deliver message to both 
-
-  **Note 2:** Don't forget that order of pipeline steps matters.
-  ```
-  deliver sql
-  destination postmaster@example.org { deliver local }
-  ```
-  In this case messages for postmaster@example.org will be delivered to
-  **both** 'sql' and 'local' storage.
+  "Rule" can be either domain name, full address (should include `@`) or
+  regular expression that should match full address.
 
   Example: Deliver to "local" all messages for mailboxes on example.org and all other - to "dummy".
   ```
   destination example.org { deliver local }
   deliver dummy
   ```
+
+  **Note:** Don't forget that order of pipeline steps matters.
+  ```
+  deliver sql
+  destination postmaster@example.org { deliver local }
+  ```
+  In this case messages for postmaster@example.org will be delivered to
+  **both** 'sql' and 'local' storage.
 
 
 Complete SMTP block example using custom pipeline:

--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -172,8 +172,35 @@ You can add any number of steps you want using following directives:
   - `src_hostname`
     Hostname reported by the client in the EHLO/HELO command.
 
-  See below for example.
+    Example:
+    ```
+    match rcpt "/@emersion.fr$/" {
+        filter dkim verify
+        deliver local
+    }
+    ```
 
+
+* `destination <recipient...> { ... }`
+
+  Execute subblock only if message does have at least one recipient matching
+  any of the specified rules.
+
+  "Rule" can be either domain name, full address or regular expression.
+
+  **Note:** If rule matches recipient - it will be removed from delivery context,
+    thus no steps after this destination block will see this recipient.
+
+  This ensures that the following example will not deliver message to both 
+
+  Example: Deliver to "local" all messages for mailboxes on example.org and all other - to "dummy".
+  ```
+  destination example.org { delivery local }
+  delivery dummy
+  ```
+
+
+Complete SMTP block example using custom pipeline:
 
 ```
 smtp smtp://0.0.0.0:25 smtps://0.0.0.0:587 {
@@ -181,15 +208,14 @@ smtp smtp://0.0.0.0:25 smtps://0.0.0.0:587 {
     auth pam
     hostname emersion.fr
 
-    match rcpt "/@emersion.fr$/" {
+    destination emersion.fr {
         filter dkim verify
         deliver local
     }
-    match no rcpt "/@emersion.fr$/" {
-        require_auth
-        filter dkim sign
-        deliver out_queue
-    }
+
+    require_auth
+    filter dkim sign
+    deliver out-queue
 }
 ```
 

--- a/maddy.conf
+++ b/maddy.conf
@@ -16,20 +16,22 @@ sql {
 
 smtp smtp://0.0.0.0:25 {
     # Deliver all mail for @example.org into sql module storage.
-    delivery sql local_only
+    destination example.org {
+        deliver sql
+    }
 }
 
 submission smtps://0.0.0.0:465 smtp://0.0.0.0:587 {
     # Use sql module for authentication.
     auth sql
-    match rcpt_domain example.org {
-        # Deliver all mail for @example.org into sql module storage.
-        delivery sql local_only
+
+    # Deliver all mail for @example.org into sql module storage.
+    destination example.org {
+        deliver sql
     }
-    match no rcpt_domain example.org {
-        # No remote delivery is implemented now, just deliver it to /dev/null for now.
-        delivery dummy
-    }
+
+    # No remote delivery is implemented now, just deliver it to /dev/null for now.
+    deliver dummy
 }
 
 imap imaps://0.0.0.0:993 imap://0.0.0.0:143 {

--- a/module/filter.go
+++ b/module/filter.go
@@ -58,7 +58,7 @@ type DeliveryContext struct {
 	Opts map[string]string
 }
 
-// DeepCopy method creates a copy of the DeliveryContext structure, also
+// DeepCopy creates a copy of the DeliveryContext structure, also
 // copying contents of the maps and slices.
 //
 // There are two exceptions, however:
@@ -69,7 +69,7 @@ func (ctx *DeliveryContext) DeepCopy() *DeliveryContext {
 	// There is no good way to copy net.Addr, but it should not be
 	// modified by anything anyway so we are safe.
 
-	cpy.Ctx = make(map[string]interface{})
+	cpy.Ctx = make(map[string]interface{}, len(ctx.Ctx))
 	for k, v := range ctx.Ctx {
 		// TODO: This is going to cause troubes if Ctx value is itself
 		// reference-based type like slice or map.

--- a/module/filter.go
+++ b/module/filter.go
@@ -58,6 +58,39 @@ type DeliveryContext struct {
 	Opts map[string]string
 }
 
+// DeepCopy method creates a copy of the DeliveryContext structure, also
+// copying contents of the maps and slices.
+//
+// There are two exceptions, however:
+// - SrcAddr is not copied and copys field references original value.
+// - Slice/map/pointer values in cpy.Ctx are not copied.
+func (ctx *DeliveryContext) DeepCopy() *DeliveryContext {
+	cpy := *ctx
+	// There is no good way to copy net.Addr, but it should not be
+	// modified by anything anyway so we are safe.
+
+	cpy.Ctx = make(map[string]interface{})
+	for k, v := range ctx.Ctx {
+		// TODO: This is going to cause troubes if Ctx value is itself
+		// reference-based type like slice or map.
+		//
+		// However, since we want to have Ctx values settable and referencable
+		// by configuration, they should not use any complex types.
+		// Probably ints, strings, bools but not more.
+		cpy.Ctx[k] = v
+	}
+
+	cpy.To = make([]string, 0, len(ctx.To))
+	for _, rcpt := range ctx.To {
+		cpy.To = append(cpy.To, rcpt)
+	}
+
+	// Opts should not be shared between calls.
+	cpy.Opts = nil
+
+	return &cpy
+}
+
 var ErrSilentDrop = errors.New("message is dropped by filter")
 
 // Filter is the interface implemented by modules that can perform arbitrary

--- a/smtp.go
+++ b/smtp.go
@@ -185,7 +185,7 @@ func (endp *SMTPEndpoint) setConfig(cfg *config.Map) error {
 
 	for _, entry := range remainingDirs {
 		switch entry.Name {
-		case "filter", "deliver", "match", "stop", "require_auth":
+		case "filter", "deliver", "match", "destination", "stop", "require_auth":
 			step, err := StepFromCfg(entry)
 			if err != nil {
 				return err

--- a/smtppipeline.go
+++ b/smtppipeline.go
@@ -284,7 +284,7 @@ type destinationStep struct {
 }
 
 func (step *destinationStep) Pass(ctx *module.DeliveryContext, msg io.Reader) (io.Reader, bool, error) {
-	ctxCpy := *ctx
+	ctxCpy := ctx.DeepCopy()
 	unmatchedRcpts := make([]string, 0, len(ctx.To))
 	ctxCpy.To = make([]string, 0, len(ctx.To))
 	for _, rcpt := range ctx.To {
@@ -308,7 +308,7 @@ func (step *destinationStep) Pass(ctx *module.DeliveryContext, msg io.Reader) (i
 	//		 ctxCpy.To contains matched rcpts, ctx.To contains unmatched
 	ctx.To = unmatchedRcpts
 
-	return passThroughPipeline(step.substeps, &ctxCpy, msg)
+	return passThroughPipeline(step.substeps, ctxCpy, msg)
 }
 
 func passThroughPipeline(steps []SMTPPipelineStep, ctx *module.DeliveryContext, msg io.Reader) (io.Reader, bool, error) {

--- a/smtppipeline.go
+++ b/smtppipeline.go
@@ -308,7 +308,8 @@ func (step *destinationStep) Pass(ctx *module.DeliveryContext, msg io.Reader) (i
 	//		 ctxCpy.To contains matched rcpts, ctx.To contains unmatched
 	ctx.To = unmatchedRcpts
 
-	return passThroughPipeline(step.substeps, ctxCpy, msg)
+	newBody, shouldContinue, err := passThroughPipeline(step.substeps, ctxCpy, msg)
+	return newBody, shouldContinue && len(ctx.To) != 0, err
 }
 
 func passThroughPipeline(steps []SMTPPipelineStep, ctx *module.DeliveryContext, msg io.Reader) (io.Reader, bool, error) {

--- a/smtppipeline.go
+++ b/smtppipeline.go
@@ -138,26 +138,7 @@ func (step matchStep) Pass(ctx *module.DeliveryContext, msg io.Reader) (io.Reade
 		return nil, true, nil
 	}
 
-	currentMsg := msg
-	var buf bytes.Buffer
-	for _, substep := range step.substeps {
-		r, cont, err := substep.Pass(ctx, currentMsg)
-		if !cont {
-			return nil, cont, err
-		}
-
-		if r != nil {
-			if _, err := io.Copy(&buf, r); err != nil {
-				return nil, false, err
-			}
-			currentMsg = &buf
-		}
-	}
-
-	if currentMsg != msg {
-		return currentMsg, true, nil
-	}
-	return msg, true, nil
+	return passThroughPipeline(step.substeps, ctx, msg)
 }
 
 func (step matchStep) matches(s string) bool {
@@ -274,6 +255,116 @@ func matchStepFromCfg(node config.Node) (SMTPPipelineStep, error) {
 	return res, nil
 }
 
+type destinationCond struct {
+	value  string
+	regexp *regexp.Regexp
+}
+
+func (cond destinationCond) matches(addr string) bool {
+	if cond.regexp != nil {
+		return cond.regexp.MatchString(addr)
+	}
+
+	if strings.Contains(cond.value, "@") {
+		return cond.value == addr
+	}
+
+	parts := strings.Split(addr, "@")
+	if len(parts) != 2 {
+		return false
+	}
+
+	// Domains are always case-sensetive.
+	return strings.ToLower(parts[1]) == strings.ToLower(cond.value)
+}
+
+type destinationStep struct {
+	conds    []destinationCond
+	substeps []SMTPPipelineStep
+}
+
+func (step *destinationStep) Pass(ctx *module.DeliveryContext, msg io.Reader) (io.Reader, bool, error) {
+	ctxCpy := *ctx
+	unmatchedRcpts := make([]string, 0, len(ctx.To))
+	ctxCpy.To = make([]string, 0, len(ctx.To))
+	for _, rcpt := range ctx.To {
+		for _, cond := range step.conds {
+			if cond.matches(rcpt) {
+				ctxCpy.To = append(ctxCpy.To, rcpt)
+				break
+			} else {
+				unmatchedRcpts = append(unmatchedRcpts, rcpt)
+			}
+		}
+	}
+
+	if len(ctxCpy.To) == 0 {
+		return nil, true, nil
+	}
+
+	// Remove matched recipients from original context value, so only one
+	// 'destination' block will ever handle particular recipient.
+	// Note: we are passing ctxCpy to substeps, not ctx.
+	//		 ctxCpy.To contains matched rcpts, ctx.To contains unmatched
+	ctx.To = unmatchedRcpts
+
+	return passThroughPipeline(step.substeps, &ctxCpy, msg)
+}
+
+func passThroughPipeline(steps []SMTPPipelineStep, ctx *module.DeliveryContext, msg io.Reader) (io.Reader, bool, error) {
+	currentMsg := msg
+	var buf bytes.Buffer
+	for _, substep := range steps {
+		r, cont, err := substep.Pass(ctx, currentMsg)
+		if !cont {
+			return nil, cont, err
+		}
+
+		if r != nil {
+			if _, err := io.Copy(&buf, r); err != nil {
+				return nil, false, err
+			}
+			currentMsg = &buf
+		}
+	}
+
+	if currentMsg != msg {
+		return currentMsg, true, nil
+	}
+	return msg, true, nil
+}
+
+func destinationStepFromCfg(node config.Node) (SMTPPipelineStep, error) {
+	if len(node.Args) == 0 {
+		return nil, errors.New("required at least one condition")
+	}
+
+	step := destinationStep{}
+
+	for _, arg := range node.Args {
+		if strings.HasPrefix(arg, "/") && strings.HasSuffix(arg, "/") {
+			re, err := regexp.Compile(arg[1 : len(arg)-1])
+			if err != nil {
+				return nil, err
+			}
+
+			step.conds = append(step.conds, destinationCond{regexp: re})
+		} else {
+			step.conds = append(step.conds, destinationCond{value: arg})
+		}
+	}
+
+	for _, child := range node.Children {
+		substep, err := StepFromCfg(child)
+		if err != nil {
+			return nil, err
+		}
+		step.substeps = append(step.substeps, substep)
+	}
+
+	return &step, nil
+}
+
 func StepFromCfg(node config.Node) (SMTPPipelineStep, error) {
 	switch node.Name {
 	case "filter":
@@ -282,6 +373,8 @@ func StepFromCfg(node config.Node) (SMTPPipelineStep, error) {
 		return deliverStepFromCfg(node)
 	case "match":
 		return matchStepFromCfg(node)
+	case "destination":
+		return destinationStepFromCfg(node)
 	case "stop":
 		return stopStep{}, nil
 	case "require_auth":

--- a/smtppipeline.go
+++ b/smtppipeline.go
@@ -321,7 +321,8 @@ func passThroughPipeline(steps []SMTPPipelineStep, ctx *module.DeliveryContext, 
 			return nil, cont, err
 		}
 
-		if r != nil {
+		if r != nil && r != &buf {
+			buf.Reset()
 			if _, err := io.Copy(&buf, r); err != nil {
 				return nil, false, err
 			}

--- a/sql.go
+++ b/sql.go
@@ -95,29 +95,6 @@ func (sqlm *SQLStorage) Deliver(ctx module.DeliveryContext, msg io.Reader) error
 			return errors.New("Deliver: missing domain part")
 		}
 
-		if _, ok := ctx.Opts["local_only"]; ok {
-			hostname := ctx.Opts["hostname"]
-			if hostname == "" {
-				hostname = ctx.OurHostname
-			}
-
-			if parts[1] != hostname {
-				sqlm.Log.Debugf("local_only, skipping %s", rcpt)
-				continue
-			}
-		}
-		if _, ok := ctx.Opts["remote_only"]; ok {
-			hostname := ctx.Opts["hostname"]
-			if hostname == "" {
-				hostname = ctx.OurHostname
-			}
-
-			if parts[1] == hostname {
-				sqlm.Log.Debugf("remote_only, skipping %s", rcpt)
-				continue
-			}
-		}
-
 		u, err := sqlm.GetExistingUser(parts[0])
 		if err != nil {
 			sqlm.Log.Debugf("failed to get user for %s: %v", rcpt, err)


### PR DESCRIPTION
As described in https://github.com/emersion/maddy/issues/32#issuecomment-481628214.

#### CONFIG_REFERENCE.md
* `destination <recipient...> { ... }`

  Execute subblock only if message does have at least one recipient matching
  any of the specified rules.

  "Rule" can be either domain name, full address or regular expression.

  **Note:** If rule matches recipient - it will be removed from delivery context,
    thus no steps after this destination block will see this recipient.

  This ensures that the following example will not deliver message to both 

  Example: Deliver to "local" all messages for mailboxes on example.org and all other - to "dummy".
  ```
  destination example.org { delivery local }
  delivery dummy
  ```