### PR TITLE
Verify return-path for incoming messages

### DIFF
--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -147,6 +147,22 @@ You can add any number of steps you want using following directives:
   Stop processing with "access denied" error if the client is not authenticated
   non-anonymously.
 
+* `check_source_hostname [required]`
+  Check that source server hostname (from EHLO/HELO command) resolves to source
+  server IP. If `required` argument is present - message will be rejected on
+  check failure.
+
+* `check_source_mx [required]`
+  Check that domain in MAIL FROM command does have a MX record pointing to
+  source server. If `required` argument is present - message will be rejected on
+  check failure.
+
+* `check_source_rdns [required]`
+  Check that source server IP does have a PTR record point to the domain
+  specified in EHLO/HELO command. If `required` argument is present - message
+  will be rejected on check failure.
+
+
 * `match [no] <field> <subtring>  { ... }`
   `match [no] <field> /<regexp>/  { ... }`
 

--- a/maddy.conf
+++ b/maddy.conf
@@ -15,6 +15,12 @@ sql {
 }
 
 smtp smtp://0.0.0.0:25 {
+    # Verify that hostname in EHLO/HELO resolves to the source IP. Fail if it is not.
+    check_source_hostname required
+    # Verify that domain in MAIL FROM does have a MX record pointing to the
+    # source server. Fail if it is not.
+    check_source_mx required
+
     # Deliver all mail for @example.org into sql module storage.
     delivery sql local_only
 }

--- a/smtppipeline.go
+++ b/smtppipeline.go
@@ -30,10 +30,13 @@ type checkSourceHostnameStep struct {
 
 func checkSourceHostnameStepFromCfg(node config.Node) (SMTPPipelineStep, error) {
 	required := false
-	if len(node.Args) >= 0 {
-		if node.Args[0] == "required" {
-			required = true
-		}
+	if len(node.Args) > 1 {
+		return nil, errors.New("check_source_hostname: expected 0 or 1 argument")
+	}
+	if node.Args[0] == "required" {
+		required = true
+	} else {
+		return nil, errors.New("check_source_hostname: unexpected argument")
 	}
 
 	return checkSourceHostnameStep{
@@ -77,10 +80,13 @@ type checkSourceMxStep struct {
 
 func checkSourceMxStepFromCfg(node config.Node) (SMTPPipelineStep, error) {
 	required := false
-	if len(node.Args) >= 0 {
-		if node.Args[0] == "required" {
-			required = true
-		}
+	if len(node.Args) > 1 {
+		return nil, errors.New("check_source_mx: expected 0 or 1 argument")
+	}
+	if node.Args[0] == "required" {
+		required = true
+	} else {
+		return nil, errors.New("check_source_mx: unexpected argument")
 	}
 
 	return checkSourceMxStep{
@@ -125,10 +131,13 @@ type checkSourceReverseDNSStep struct {
 
 func checkSourceReverseDNSStepFromCfg(node config.Node) (SMTPPipelineStep, error) {
 	required := false
-	if len(node.Args) >= 0 {
-		if node.Args[0] == "required" {
-			required = true
-		}
+	if len(node.Args) > 1 {
+		return nil, errors.New("check_source_rdns: expected 0 or 1 argument")
+	}
+	if node.Args[0] == "required" {
+		required = true
+	} else {
+		return nil, errors.New("check_source_rdns: unexpected argument")
 	}
 
 	return checkSourceReverseDNSStep{

--- a/smtppipeline.go
+++ b/smtppipeline.go
@@ -101,6 +101,11 @@ func (s checkSourceMxStep) Pass(ctx *module.DeliveryContext, _ io.Reader) (io.Re
 	}
 	domain := parts[1]
 
+	ipAddr, ok := ctx.SrcAddr.(*net.IPAddr)
+	if !ok {
+		return nil, true, nil
+	}
+
 	srcMx, err := net.LookupMX(domain)
 	if err != nil {
 		ctx.Ctx["src_mx_check"] = false
@@ -112,7 +117,7 @@ func (s checkSourceMxStep) Pass(ctx *module.DeliveryContext, _ io.Reader) (io.Re
 	}
 
 	for _, mx := range srcMx {
-		if mx.Host == ctx.SrcHostname {
+		if mx.Host == ctx.SrcHostname || mx.Host == ipAddr.String() {
 			ctx.Ctx["src_mx_check"] = true
 			return nil, true, nil
 		}


### PR DESCRIPTION
This should implement all the pipeline steps from issue #41 correctly.

Closes #41.