### PR TITLE
Inline modules instances implementation

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,6 +35,13 @@ func createModule(args []string) (module.Module, error) {
 	return newMod(modName, instName)
 }
 
+func moduleFromNode(node *config.Node) (module.Module, error) {
+	if node.Children != nil {
+		return createModule(node.Args)
+	}
+	return module.GetInstance(node.Args[0])
+}
+
 func initInlineModule(modObj module.Module, globals map[string]interface{}, node *config.Node) error {
 	// This is to ensure modules Init will see expected node layout if it breaks
 	// Map abstraction and works with map.Values.
@@ -58,18 +65,9 @@ func deliverTarget(globals map[string]interface{}, node *config.Node) (module.De
 		return nil, config.NodeErr(node, "expected at least 1 argument")
 	}
 
-	var modObj module.Module
-	var err error
-	if node.Children != nil {
-		modObj, err = createModule(node.Args)
-		if err != nil {
-			return nil, config.NodeErr(node, "%s", err.Error())
-		}
-	} else {
-		modObj, err = module.GetInstance(node.Args[0])
-		if err != nil {
-			return nil, config.NodeErr(node, "%s", err.Error())
-		}
+	modObj, err := moduleFromNode(node)
+	if err != nil {
+		return nil, config.NodeErr(node, "%s", err.Error())
 	}
 
 	target, ok := modObj.(module.DeliveryTarget)
@@ -91,18 +89,9 @@ func authDirective(m *config.Map, node *config.Node) (interface{}, error) {
 		return nil, m.MatchErr("expected at least 1 argument")
 	}
 
-	var modObj module.Module
-	var err error
-	if node.Children != nil {
-		modObj, err = createModule(node.Args)
-		if err != nil {
-			return nil, m.MatchErr("%s", err.Error())
-		}
-	} else {
-		modObj, err = module.GetInstance(node.Args[0])
-		if err != nil {
-			return nil, m.MatchErr("%s", err.Error())
-		}
+	modObj, err := moduleFromNode(node)
+	if err != nil {
+		return nil, m.MatchErr("%s", err.Error())
 	}
 
 	provider, ok := modObj.(module.AuthProvider)
@@ -124,18 +113,9 @@ func storageDirective(m *config.Map, node *config.Node) (interface{}, error) {
 		return nil, m.MatchErr("expected at least 1 argument")
 	}
 
-	var modObj module.Module
-	var err error
-	if node.Children != nil {
-		modObj, err = createModule(node.Args)
-		if err != nil {
-			return nil, m.MatchErr("%s", err.Error())
-		}
-	} else {
-		modObj, err = module.GetInstance(node.Args[0])
-		if err != nil {
-			return nil, m.MatchErr("%s", err.Error())
-		}
+	modObj, err := moduleFromNode(node)
+	if err != nil {
+		return nil, m.MatchErr("%s", err.Error())
 	}
 
 	backend, ok := modObj.(module.Storage)

--- a/config/env.go
+++ b/config/env.go
@@ -7,8 +7,10 @@ import (
 )
 
 func expandEnvironment(nodes []Node) []Node {
+	// If nodes is nil - don't replace with empty slice, as nil indicates "no
+	// block".
 	if nodes == nil {
-		return nodes
+		return nil
 	}
 
 	replacer := buildEnvReplacer()

--- a/config/env.go
+++ b/config/env.go
@@ -7,6 +7,10 @@ import (
 )
 
 func expandEnvironment(nodes []Node) []Node {
+	if nodes == nil {
+		return nodes
+	}
+
 	replacer := buildEnvReplacer()
 	newNodes := make([]Node, 0, len(nodes))
 	for _, node := range nodes {

--- a/config/imports.go
+++ b/config/imports.go
@@ -6,7 +6,8 @@ import (
 )
 
 func (ctx *parseContext) expandImports(node *Node, expansionDepth int) error {
-	// Don't allocate slice if we are not going to do anything anyway.
+	// Leave nil value as is because it is used as non-existent block indicator
+	// (vs empty slice - empty block).
 	if node.Children == nil {
 		return nil
 	}

--- a/config/imports.go
+++ b/config/imports.go
@@ -6,6 +6,11 @@ import (
 )
 
 func (ctx *parseContext) expandImports(node *Node, expansionDepth int) error {
+	// Don't allocate slice if we are not going to do anything anyway.
+	if node.Children == nil {
+		return nil
+	}
+
 	newChildrens := make([]Node, 0, len(node.Children))
 	containsImports := false
 	for _, child := range node.Children {

--- a/config/parse.go
+++ b/config/parse.go
@@ -113,6 +113,8 @@ func (ctx *parseContext) isSnippet(name string) (bool, string) {
 // To stay consistent with readNode after this function returns the lexer's cursor points
 // to the last token of the black (closing brace).
 func (ctx *parseContext) readNodes() ([]Node, error) {
+	// It is not 'var res []Node' becuase we want empty
+	// but non-nil Children slice for empty braces.
 	res := []Node{}
 
 	// Refuse to continue is nesting is too big.

--- a/config/parse_test.go
+++ b/config/parse_test.go
@@ -20,9 +20,9 @@ var cases = []struct {
 			{
 				Name:     "a",
 				Args:     []string{},
+				Children: nil,
 				File:     "test",
 				Line:     1,
-				Children: []Node{},
 			},
 		},
 		false,
@@ -34,7 +34,7 @@ var cases = []struct {
 			{
 				Name:     "a",
 				Args:     []string{"a1", "a2"},
-				Children: []Node{},
+				Children: nil,
 				File:     "test",
 				Line:     1,
 			},
@@ -83,14 +83,14 @@ var cases = []struct {
 					{
 						Name:     "a_child1",
 						Args:     []string{"c1arg1", "c1arg2"},
-						Children: []Node{},
+						Children: nil,
 						File:     "test",
 						Line:     2,
 					},
 					{
 						Name:     "a_child2",
 						Args:     []string{"c2arg1", "c2arg2"},
-						Children: []Node{},
+						Children: nil,
 						File:     "test",
 						Line:     3,
 					},
@@ -121,14 +121,14 @@ var cases = []struct {
 			{
 				Name:     "a",
 				Args:     []string{},
-				Children: []Node{},
+				Children: nil,
 				File:     "test",
 				Line:     1,
 			},
 			{
 				Name:     "b",
 				Args:     []string{},
-				Children: []Node{},
+				Children: nil,
 				File:     "test",
 				Line:     2,
 			},
@@ -143,14 +143,14 @@ var cases = []struct {
 			{
 				Name:     "a",
 				Args:     []string{"a1", "a2"},
-				Children: []Node{},
+				Children: nil,
 				File:     "test",
 				Line:     1,
 			},
 			{
 				Name:     "b",
 				Args:     []string{"b1", "b2"},
-				Children: []Node{},
+				Children: nil,
 				File:     "test",
 				Line:     2,
 			},
@@ -179,14 +179,14 @@ var cases = []struct {
 					{
 						Name:     "a_child1",
 						Args:     []string{"c1arg1", "c1arg2"},
-						Children: []Node{},
+						Children: nil,
 						File:     "test",
 						Line:     2,
 					},
 					{
 						Name:     "a_child2",
 						Args:     []string{"c2arg1", "c2arg2"},
-						Children: []Node{},
+						Children: nil,
 						File:     "test",
 						Line:     3,
 					},
@@ -197,7 +197,7 @@ var cases = []struct {
 			{
 				Name:     "b",
 				Args:     []string{},
-				Children: []Node{},
+				Children: nil,
 				File:     "test",
 				Line:     4,
 			},
@@ -215,7 +215,7 @@ var cases = []struct {
 					{
 						Name:     "a_child1",
 						Args:     []string{"c1arg1", "c1arg2"},
-						Children: []Node{},
+						Children: nil,
 						File:     "test",
 						Line:     1,
 					},
@@ -264,7 +264,7 @@ var cases = []struct {
 			{
 				Name:     "b",
 				Args:     []string{"b1"},
-				Children: []Node{},
+				Children: nil,
 				File:     "test",
 				Line:     2,
 			},
@@ -278,7 +278,7 @@ var cases = []struct {
 			{
 				Name:     "a",
 				Args:     []string{"ABCDEF"},
-				Children: []Node{},
+				Children: nil,
 				File:     "test",
 				Line:     1,
 			},
@@ -292,7 +292,7 @@ var cases = []struct {
 			{
 				Name:     "a",
 				Args:     []string{"ABC2 DEF2"},
-				Children: []Node{},
+				Children: nil,
 				File:     "test",
 				Line:     1,
 			},
@@ -306,7 +306,7 @@ var cases = []struct {
 			{
 				Name:     "a",
 				Args:     []string{""},
-				Children: []Node{},
+				Children: nil,
 				File:     "test",
 				Line:     1,
 			},
@@ -320,7 +320,7 @@ var cases = []struct {
 			{
 				Name:     "a",
 				Args:     []string{""},
-				Children: []Node{},
+				Children: nil,
 				File:     "test",
 				Line:     1,
 			},
@@ -334,7 +334,7 @@ var cases = []struct {
 			{
 				Name:     "a",
 				Args:     []string{"{%TESTING_VARIABLE3"},
-				Children: []Node{},
+				Children: nil,
 				File:     "test",
 				Line:     1,
 			},
@@ -349,7 +349,7 @@ var cases = []struct {
 			{
 				Name:     "a",
 				Args:     []string{},
-				Children: []Node{},
+				Children: nil,
 				File:     "test",
 				Line:     1,
 			},
@@ -426,12 +426,12 @@ func TestRead(t *testing.T) {
 			if !reflect.DeepEqual(case_.tree, tree) {
 				t.Log("parse result mismatch")
 				t.Log("expected:")
-				t.Logf("%+v", case_.tree)
+				t.Logf("%+#v", case_.tree)
 				for _, node := range case_.tree {
 					printTree(t, &node, 0)
 				}
 				t.Log("actual:")
-				t.Logf("%+v", tree)
+				t.Logf("%+#v", tree)
 				for _, node := range tree {
 					printTree(t, &node, 0)
 				}

--- a/maddy.conf.5.scd
+++ b/maddy.conf.5.scd
@@ -67,15 +67,13 @@ directive0 {
 }
 ```
 
-Level of nesting is limited, but you should not ever hit the limit with correct
+Level of nesting is limited, but you should never hit the limit with correct
 configuration.
 
-An empty block is equivalent to no block, the following directives are absolutely
-the same from maddy perspective.
-
+In most cases, an empty block is equivalent to no block:
 ```
 directive { }
-directive2
+directive2 # same as above
 ```
 
 ## Environment variables
@@ -189,6 +187,45 @@ is same as just
 
 Remaining man page sections describe various modules you can use in your
 configuration.
+
+## "Inline" configuration blocks
+
+In most cases where you are supposed to specify configuration block name, you
+can instead write module name and include configuration block itself.
+
+Like that:
+```
+something {
+    auth sql {
+        driver sqlite3
+        dsn auth.db
+    }
+}
+```
+instead of
+```
+sql thing_name {
+    driver sqlite3
+    dsn auth.db
+}
+
+something {
+    auth thing_name
+}
+```
+
+Exceptions to this rule are explicitly noted in the documentation.
+
+*Note* that in certain cases you also have to specify a name for "inline"
+configuration block. This is required when the used module uses configuration
+block name as a key to store persistent data.
+```
+smtp ... {
+    deliver queue block_name_here {
+        target remote
+    }
+}
+```
 
 
 # GLOBAL DIRECTIVES
@@ -478,14 +515,14 @@ will be returned to the message source (SMTP client).
 
 You can add any number of steps you want using the following directives:
 
-## filter <instnace_name> [opts]
+## filter <instnace_name>
 
 Apply a "filter" to a message, instance_name is the configuration block name.
 You can pass additional parameters to filter by adding key=value pairs to the
 end directive, you can omit the value and just specify key if it is
 supported by the filter.
 
-## deliver <instance_name> [opts]
+## deliver <instance_name>
 
 Same as the filter directive, but also executes certain pre-delivery
 operations required by RFC 5321 (SMTP), i.e. it adds Received header to

--- a/module/filter.go
+++ b/module/filter.go
@@ -61,9 +61,6 @@ type DeliveryContext struct {
 	// For example, spam filter may set Ctx[spam] to true to tell storage
 	// backend to mark message as spam.
 	Ctx map[string]interface{}
-
-	// Custom options passed to filter from server configuration.
-	Opts map[string]string
 }
 
 // DeepCopy creates a copy of the DeliveryContext structure, also
@@ -92,9 +89,6 @@ func (ctx *DeliveryContext) DeepCopy() *DeliveryContext {
 	for _, rcpt := range ctx.To {
 		cpy.To = append(cpy.To, rcpt)
 	}
-
-	// Opts should not be shared between calls.
-	cpy.Opts = nil
 
 	return &cpy
 }

--- a/queue.go
+++ b/queue.go
@@ -81,12 +81,18 @@ func (q *Queue) Init(cfg *config.Map) error {
 	cfg.Bool("debug", true, &q.Log.Debug)
 	cfg.Int("max_tries", false, false, 8, &q.maxTries)
 	cfg.Int("workers", false, false, 16, &workers)
-	cfg.String("location", false, false, filepath.Join(StateDirectory(cfg.Globals), q.name), &q.location)
+	cfg.String("location", false, false, "", &q.location)
 	cfg.Custom("target", false, true, nil, deliverDirective, &q.Target)
 	if _, err := cfg.Process(); err != nil {
 		return err
 	}
 
+	if q.location == "" && q.name == "" {
+		return errors.New("queue: need explicit location directive or config block name if defined inline")
+	}
+	if q.location == "" {
+		q.location = filepath.Join(StateDirectory(cfg.Globals), q.name)
+	}
 	if !filepath.IsAbs(q.location) {
 		q.location = filepath.Join(StateDirectory(cfg.Globals), q.location)
 	}

--- a/smtp.go
+++ b/smtp.go
@@ -175,7 +175,7 @@ func (endp *SMTPEndpoint) setConfig(cfg *config.Map) error {
 	endp.serv.ReadTimeout = time.Duration(readTimeoutSecs) * time.Second
 
 	for _, entry := range remainingDirs {
-		step, err := StepFromCfg(entry)
+		step, err := StepFromCfg(cfg.Globals, entry)
 		if err != nil {
 			return err
 		}

--- a/smtppipeline.go
+++ b/smtppipeline.go
@@ -17,8 +17,7 @@ import (
 	"github.com/emersion/maddy/module"
 )
 
-// TODO: Consider merging SMTPPipelineStep interface with module.Filter and
-// converting check_source_* into filters.
+// TODO: Consider merging SMTPPipelineStep interface with module.Filter.
 
 type SMTPPipelineStep interface {
 	// Pass applies step's processing logic to the message.
@@ -198,18 +197,9 @@ func filterStepFromCfg(globals map[string]interface{}, node *config.Node) (SMTPP
 		return nil, config.NodeErr(node, "expected at least 1 argument")
 	}
 
-	var modObj module.Module
-	var err error
-	if node.Children != nil {
-		modObj, err = createModule(node.Args)
-		if err != nil {
-			return nil, config.NodeErr(node, "%s", err.Error())
-		}
-	} else {
-		modObj, err = module.GetInstance(node.Args[0])
-		if err != nil {
-			return nil, config.NodeErr(node, "%s", err.Error())
-		}
+	modObj, err := moduleFromNode(node)
+	if err != nil {
+		return nil, config.NodeErr(node, "%s", err.Error())
 	}
 
 	filter, ok := modObj.(module.Filter)


### PR DESCRIPTION
Per-call module options are removed from the pipeline code as they are not necessary now.

Queue module from #11 should not be allowed to be used inline without explicit instance name or storage location.

Closes #42.