### PR TITLE
Add random DeliveryID to delivery context

### DIFF
--- a/module/filter.go
+++ b/module/filter.go
@@ -47,6 +47,10 @@ type DeliveryContext struct {
 	// Our domain.
 	OurHostname string
 
+	// Unique identifier for this delivery attempt. Should be used in logs to
+	// make troubleshotting easier.
+	DeliveryID string
+
 	// Arbitrary context meta-data that can be modified by any module in
 	// pipeline. It is passed unchanged to next module in chain.
 	//

--- a/smtppipeline.go
+++ b/smtppipeline.go
@@ -257,7 +257,7 @@ func (step deliverStep) Pass(ctx *module.DeliveryContext, msg io.Reader) (io.Rea
 		}
 	}
 	received += fmt.Sprintf("\r\n\tby %s (envelope-sender <%s>)", sanitizeString(ctx.OurHostname), sanitizeString(ctx.From))
-	received += fmt.Sprintf("\r\n\twith %s", ctx.SrcProto)
+	received += fmt.Sprintf("\r\n\twith %s id %s", ctx.SrcProto, ctx.DeliveryID)
 	received += fmt.Sprintf("\r\n\tfor %s; %s\r\n", to, time.Now().Format(time.RFC1123Z))
 
 	msg = io.MultiReader(strings.NewReader(received), msg)

--- a/smtppipeline.go
+++ b/smtppipeline.go
@@ -118,7 +118,7 @@ func (s checkSourceMxStep) Pass(ctx *module.DeliveryContext, _ io.Reader) (io.Re
 	if err != nil {
 		ctx.Ctx["src_mx_check"] = false
 		if s.required {
-			log.Debugf("check_source_mx: %s does not resolve, FAIL", domain)
+			log.Printf("check_source_mx: %s does not resolve, FAIL, delivery ID = %s", domain, ctx.DeliveryID)
 			return nil, false, errors.New("could not find MX records for from domain")
 		} else {
 			log.Debugf("check_source_mx: %s does not resolve, OK", domain)
@@ -135,7 +135,7 @@ func (s checkSourceMxStep) Pass(ctx *module.DeliveryContext, _ io.Reader) (io.Re
 	}
 	ctx.Ctx["src_mx_check"] = false
 	if s.required {
-		log.Printf("check_source_mx: no matching MX records for %s (%s), FAIL", ctx.SrcHostname, tcpAddr.IP)
+		log.Printf("check_source_mx: no matching MX records for %s (%s), FAIL, delivery ID = %s", ctx.SrcHostname, tcpAddr.IP, ctx.DeliveryID)
 		return nil, false, errors.New("From domain has no MX record for itself")
 	} else {
 		log.Debugln("check_source_mx: no MX records, OK")
@@ -174,7 +174,7 @@ func (s checkSourceReverseDNSStep) Pass(ctx *module.DeliveryContext, _ io.Reader
 	if err != nil || len(names) == 0 {
 		ctx.Ctx["src_rdns_check"] = false
 		if s.required {
-			log.Printf("check_source_rdns: rDNS query for %v failed (%v), FAIL", tcpAddr.IP, err)
+			log.Printf("check_source_rdns: rDNS query for %v failed (%v), FAIL, delivery ID = %s", tcpAddr.IP, err, ctx.DeliveryID)
 			return nil, false, errors.New("could look up rDNS address for source")
 		} else {
 			log.Debugf("check_source_rdns: rDNS query for %v failed (%v), OK", tcpAddr.IP, err)
@@ -193,7 +193,7 @@ func (s checkSourceReverseDNSStep) Pass(ctx *module.DeliveryContext, _ io.Reader
 	}
 	ctx.Ctx["src_rdns_check"] = false
 	if s.required {
-		log.Printf("check_source_rdns: no PTR records for %v IP pointing to %s, FAIL", tcpAddr.IP, srcDomain)
+		log.Printf("check_source_rdns: no PTR records for %v IP pointing to %s, FAIL, delivery ID = %s", tcpAddr.IP, srcDomain, ctx.DeliveryID)
 		return nil, false, errors.New("rDNS name does not match source hostname")
 	} else {
 		log.Debugf("check_source_rdns: no PTR records for %v IP pointing to %s, OK", tcpAddr.IP, srcDomain)

--- a/sql.go
+++ b/sql.go
@@ -97,7 +97,7 @@ func (sqlm *SQLStorage) Deliver(ctx module.DeliveryContext, msg io.Reader) error
 
 		u, err := sqlm.GetExistingUser(parts[0])
 		if err != nil {
-			sqlm.Log.Debugf("failed to get user for %s: %v", rcpt, err)
+			sqlm.Log.Printf("failed to get user for %s (delivery ID = %s): %v", rcpt, ctx.DeliveryID, err)
 			if err == sqlstore.ErrUserDoesntExists {
 				return &smtp.SMTPError{
 					Code:    550,
@@ -124,7 +124,7 @@ func (sqlm *SQLStorage) Deliver(ctx module.DeliveryContext, msg io.Reader) error
 					return err
 				}
 			} else {
-				sqlm.Log.Debugf("failed to get inbox for %s: %v", rcpt, err)
+				sqlm.Log.Printf("failed to get inbox for %s (delivery ID = %s): %v", rcpt, ctx.DeliveryID, err)
 				return err
 			}
 		}
@@ -137,7 +137,7 @@ func (sqlm *SQLStorage) Deliver(ctx module.DeliveryContext, msg io.Reader) error
 			length: len(headerPrefix) + buf.Len(),
 		}
 		if err := mbox.CreateMessage([]string{}, time.Now(), msg); err != nil {
-			sqlm.Log.Debugf("failed to save msg for %s: %v", rcpt, err)
+			sqlm.Log.Printf("failed to save msg for %s (delivery ID = %s): %v", rcpt, ctx.DeliveryID, err)
 			return err
 		}
 	}


### PR DESCRIPTION
The ID is printed to logs and added to the Received header, so it is very useful for troubleshooting.