### PR TITLE
Fix binding to IPv6 addresses

### DIFF
--- a/address.go
+++ b/address.go
@@ -37,7 +37,13 @@ func (a Address) String() string {
 	if s != "" {
 		s += "://"
 	}
-	s += a.Host
+
+	host := a.Host
+	if strings.Contains(host, ":") {
+		host = "[" + host + "]"
+	}
+	s += host
+
 	if a.Port != "" &&
 		((scheme == "imaps" && a.Port != "993") ||
 			(scheme == "imap" && a.Port != "143") ||
@@ -76,7 +82,7 @@ func (a Address) Address() string {
 	if a.Scheme == "lmtp+unix" {
 		return a.Path
 	} else {
-		return a.Host + ":" + a.Port
+		return net.JoinHostPort(a.Host, a.Port)
 	}
 }
 

--- a/address_test.go
+++ b/address_test.go
@@ -1,0 +1,33 @@
+package maddy
+
+import (
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestStandardizeAddress(t *testing.T) {
+	for _, expected := range []Address{
+		{Original: "smtp://0.0.0.0", Scheme: "smtp", Host: "0.0.0.0", Port: "25"},
+		{Original: "smtp://[::]", Scheme: "smtp", Host: "::", Port: "25"},
+		{Original: "smtp://0.0.0.0:10025", Scheme: "smtp", Host: "0.0.0.0", Port: "10025"},
+		{Original: "smtp://[::]:10025", Scheme: "smtp", Host: "::", Port: "10025"},
+	} {
+		actual, err := standardizeAddress(expected.Original)
+		if err != nil {
+			t.Error("Unexpected failure:", err)
+			return
+		}
+
+		if !reflect.DeepEqual(expected, actual) {
+			t.Errorf("Didn't parse URL %q correctly", expected.Original)
+			return
+		}
+
+		addrStr := actual.Address()
+		if addrStr != net.JoinHostPort(expected.Host, expected.Port) {
+			t.Errorf("Address() returned wrong value: %q for %q", addrStr, expected.Original)
+			return
+		}
+	}
+}


### PR DESCRIPTION
Attempt #2 at https://github.com/emersion/maddy/pull/65 , this time with a better approach.

Both `Address.String()` and `Address.Address()` are modified to handle IPv6 literals appropriately.