### PR TITLE
Support for per-domain authentication & storage and user@domain login names

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,35 @@
+package maddy
+
+import "strings"
+
+func checkDomainAuth(username string, perDomain bool, allowedDomains []string) (loginName string, allowed bool) {
+	var accountName, domain string
+	if perDomain {
+		parts := strings.Split(username, "@")
+		if len(parts) != 2 {
+			return "", false
+		}
+		domain = parts[1]
+		accountName = username
+	} else {
+		parts := strings.Split(username, "@")
+		accountName = parts[0]
+		if len(parts) == 2 {
+			domain = parts[1]
+		}
+	}
+
+	allowed = domain == ""
+	if allowedDomains != nil && domain != "" {
+		for _, allowedDomain := range allowedDomains {
+			if domain == allowedDomain {
+				allowed = true
+			}
+		}
+		if !allowed {
+			return "", false
+		}
+	}
+
+	return accountName, allowed
+}

--- a/config/map.go
+++ b/config/map.go
@@ -78,14 +78,24 @@ func (m *Map) Bool(name string, inheritGlobal bool, store *bool) {
 	m.Custom(name, inheritGlobal, false, func() (interface{}, error) {
 		return false, nil
 	}, func(m *Map, node *Node) (interface{}, error) {
-		if len(node.Args) != 0 {
-			return nil, m.MatchErr("unexpected arguments")
-		}
 		if len(node.Children) != 0 {
 			return nil, m.MatchErr("can't declare block here")
 		}
 
-		return true, nil
+		if len(node.Args) == 0 {
+			return true, nil
+		}
+		if len(node.Args) != 1 {
+			return nil, m.MatchErr("expected exactly 1 argument")
+		}
+
+		switch node.Args[0] {
+		case "yes":
+			return true, nil
+		case "no":
+			return false, nil
+		}
+		return nil, m.MatchErr("bool argument should be 'yes' or 'no'")
 	}, store)
 }
 

--- a/config/map.go
+++ b/config/map.go
@@ -89,6 +89,29 @@ func (m *Map) Bool(name string, inheritGlobal bool, store *bool) {
 	}, store)
 }
 
+// StringList maps configuration directive with the specified name to variable
+// referenced by 'store' pointer.
+//
+// Configuration directive must be in form 'name arbitrary_string arbitrary_string ...'
+// Where at least one argument must be present.
+//
+// See Custom function for details about inheritGlobal, required and
+// defaultVal.
+func (m *Map) StringList(name string, inheritGlobal, required bool, defaultVal []string, store *[]string) {
+	m.Custom(name, inheritGlobal, required, func() (interface{}, error) {
+		return defaultVal, nil
+	}, func(m *Map, node *Node) (interface{}, error) {
+		if len(node.Args) == 0 {
+			return nil, m.MatchErr("expected at least one argument")
+		}
+		if len(node.Children) != 0 {
+			return nil, m.MatchErr("can't declare block here")
+		}
+
+		return node.Args, nil
+	}, store)
+}
+
 // String maps configuration directive with the specified name to variable
 // referenced by 'store' pointer.
 //

--- a/imap.go
+++ b/imap.go
@@ -162,7 +162,7 @@ func (endp *IMAPEndpoint) Login(connInfo *imap.ConnInfo, username, password stri
 		return nil, imapbackend.ErrInvalidCredentials
 	}
 
-	return endp.Store.GetUser(username)
+	return endp.Store.GetOrCreateUser(username)
 }
 
 func (endp *IMAPEndpoint) EnableChildrenExt() bool {

--- a/maddy.conf
+++ b/maddy.conf
@@ -3,7 +3,11 @@
 tls cert_file_path pkey_file
 
 # hostname is used in several places, mainly in gretting for IMAP and SMTP.
-hostname example.org
+hostname mx1.example.org
+
+# auth_domains directive allows users to log in using 'user@example.org' as a
+# username in addition to just 'user'.
+auth_domains example.org
 
 # Create and initialize sql module, it provides simple authentication and
 # storage backend using one database for everything.

--- a/maddy.conf.5.scd
+++ b/maddy.conf.5.scd
@@ -301,6 +301,23 @@ Don't remove domain part when accessing the underlying storage and require it
 to be present. Can be used if you want user@domain1 and user@domain2 to be
 different accounts at the storage level.
 
+## auth_perdomain [yes/no]
+
+If yes - authentication requests that specify just username will be rejected
+as invalid and domain part will be used as part of login name.
+
+## auth_domains <domain0> [domain1] ...
+
+Domains that should be allowed in username.
+
+For example, if auth_domains is set to "domain1 domain2", then
+username, username@domain1 and username@domain2 will be accepted as valid login
+name.
+
+If used without auth_perdomain, domain part will be removed from login before
+check with underlying auth. mechanism. If auth_perdomain is set, then
+auth_domains must be also set and domain part WILL NOT be removed before check.
+
 # TLS CONFIGURATION
 
 You can specify other TLS-related options in a configuration block:
@@ -658,6 +675,11 @@ See https://sqlite.org/pragma.html for more details.
 
 Override global storage_perdomain directive.
 
+## auth_perdomain [yes/no]
+## auth_domains ...
+
+Override corresponding global directives.
+
 # QUEUE MODULE
 
 Queue module buffers messages on disk and retries delivery multiple times to
@@ -747,6 +769,12 @@ Location of the helper binary.
 ## debug [yes/no]
 
 Verbose log only for this configuration block.
+
+## auth_perdomain [yes/no]
+## auth_domains ...
+
+Override corresponding global directives.
+
 
 # PAM MODULE
 

--- a/maddy.conf.5.scd
+++ b/maddy.conf.5.scd
@@ -295,6 +295,12 @@ go build --ldflags '-X github.com/emersion/maddy.defaultLibexecDirectory=/opt/ma
 
 Enable verbose logging. You don't need that unless you are reporting a bug.
 
+## storage_perdomain [yes/no]
+
+Don't remove domain part when accessing the underlying storage and require it
+to be present. Can be used if you want user@domain1 and user@domain2 to be
+different accounts at the storage level.
+
 # TLS CONFIGURATION
 
 You can specify other TLS-related options in a configuration block:
@@ -647,6 +653,10 @@ If cache_size is not used, SQLite3 default is used. If busy_timeout is not set,
 500000 is used.
 
 See https://sqlite.org/pragma.html for more details.
+
+## storage_perdomain [yes/no]
+
+Override global storage_perdomain directive.
 
 # QUEUE MODULE
 

--- a/maddy.conf.5.scd
+++ b/maddy.conf.5.scd
@@ -291,7 +291,7 @@ flag during compilation:
 go build --ldflags '-X github.com/emersion/maddy.defaultLibexecDirectory=/opt/maddy/bin'
 ```
 
-## debug
+## debug [yes/no]
 
 Enable verbose logging. You don't need that unless you are reporting a bug.
 
@@ -422,16 +422,16 @@ Use an authentication module with a specified configuration block name. *Require
 
 Use a storage module with a specified configuration block name. *Required.*
 
-## insecure_auth
+## insecure_auth [yes/no]
 
 Allow plain-text authentication over unencrypted connections. Not recommended!
 Enabled automatically if TLS is disabled.
 
-## io_debug
+## io_debug [yes/no]
 
 Write all commands and responses to stderr.
 
-## debug
+## debug [yes/no]
 
 Enable verbose logging only for this configuration block.
 
@@ -468,11 +468,11 @@ Override the global hostname directive. The hostname is used in EHLO/HELO greeti
 
 Override global tls directive.
 
-## io_debug
+## io_debug [yes/no]
 
 Write all commands and responses to stderr.
 
-## debug
+## debug [yes/no]
 
 Enable verbose logging only for this configuration block.
 
@@ -498,7 +498,7 @@ Limit the size of incoming messages to value bytes. The default is 32 MiB.
 Use an authentication module with a specified configuration block name.
 *Required.*
 
-## submission
+## submission [yes/no]
 
 Preprocess messages before pushing them to pipeline and require authentication
 for all operations. You should use it for Submission protocol endpoints.
@@ -622,7 +622,7 @@ For PostgreSQL: https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parame
 
 Refuse to accept messages larger than `value` bytes. The default is 32 MiB.
 
-## debug
+## debug [yes/no]
 
 Enable verbose logging only for this configuration block.
 
@@ -683,7 +683,7 @@ is permanent error occured during previous attempt.
 
 Default is 4.
 
-## debug
+## debug [yes/no]
 
 Enable verbose logging only for this configuration block.
 
@@ -706,7 +706,7 @@ Override global hostname directive.
 
 Always refuse to send messages over unencrypted connections.
 
-## debug
+## debug [yes/no]
 
 Enable verbose logging only for this configuration block.
 
@@ -734,7 +734,7 @@ Valid configuration directives:
 
 Location of the helper binary.
 
-## debug
+## debug [yes/no]
 
 Verbose log only for this configuration block.
 

--- a/module/storage.go
+++ b/module/storage.go
@@ -5,10 +5,11 @@ import imapbackend "github.com/emersion/go-imap/backend"
 // Storage interface is a slightly modified go-imap's Backend interface
 // (authentication is removed).
 type Storage interface {
-	// GetUser returns User associated with user account specified by name.
+	// GetOrCreateUser returns User associated with user account specified by
+	// name.
 	//
 	// If it doesn't exists - it should be created.
-	GetUser(username string) (imapbackend.User, error)
+	GetOrCreateUser(username string) (imapbackend.User, error)
 
 	// Extensions returns list of IMAP extensions supported by backend.
 	IMAPExtensions() []string

--- a/sql.go
+++ b/sql.go
@@ -24,7 +24,9 @@ type SQLStorage struct {
 	instName string
 	Log      log.Logger
 
-	perDomain bool
+	storagePerDomain bool
+	authPerDomain    bool
+	authDomains      []string
 }
 
 type Literal struct {
@@ -61,7 +63,9 @@ func (sqlm *SQLStorage) Init(cfg *config.Map) error {
 	cfg.String("dsn", false, true, "", &dsn)
 	cfg.Int64("appendlimit", false, false, 32*1024*1024, &appendlimitVal)
 	cfg.Bool("debug", true, &sqlm.Log.Debug)
-	cfg.Bool("storage_perdomain", true, &sqlm.perDomain)
+	cfg.Bool("storage_perdomain", true, &sqlm.storagePerDomain)
+	cfg.Bool("auth_perdomain", true, &sqlm.authPerDomain)
+	cfg.StringList("auth_domains", true, false, nil, &sqlm.authDomains)
 	cfg.Int("sqlite3_cache_size", false, false, 0, &opts.CacheSize)
 	cfg.Int("sqlite3_busy_timeout", false, false, 0, &opts.BusyTimeout)
 	cfg.Bool("sqlite3_exclusive_lock", false, &opts.ExclusiveLock)
@@ -84,6 +88,10 @@ func (sqlm *SQLStorage) Init(cfg *config.Map) error {
 
 	if _, err := cfg.Process(); err != nil {
 		return err
+	}
+
+	if sqlm.authPerDomain && sqlm.authDomains == nil {
+		return errors.New("sql: auth_domains must be set if auth_perdomain is used")
 	}
 
 	if fsstoreLocation != "" {
@@ -127,12 +135,17 @@ func (sqlm *SQLStorage) EnableChildrenExt() bool {
 }
 
 func (sqlm *SQLStorage) CheckPlain(username, password string) bool {
-	return sqlm.back.CheckPlain(username, password)
+	accountName, ok := checkDomainAuth(username, sqlm.authPerDomain, sqlm.authDomains)
+	if !ok {
+		return false
+	}
+
+	return sqlm.back.CheckPlain(accountName, password)
 }
 
 func (sqlm *SQLStorage) GetOrCreateUser(username string) (backend.User, error) {
 	var accountName string
-	if sqlm.perDomain {
+	if sqlm.storagePerDomain {
 		if !strings.Contains(username, "@") {
 			return nil, errors.New("GetOrCreateUser: username@domain required")
 		}


### PR DESCRIPTION
Note about 4e804b1: It was done to allow to override globally enabled boolean directive to false on the block level. I think it might be useful with boolean flags that can be set on the global level.

Closes #57.

